### PR TITLE
Add cv-mirror-mcp to Integration Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Specialized tools for specific platforms and use cases.
 - [@modelcontextprotocol/server-everything](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) 📱 🏠 - Comprehensive MCP feature testing
 - [calclavia/mcp-obsidian](https://github.com/calclavia/mcp-obsidian) 📱 🏠 - Obsidian vault integration
 - [rusiaaman/wcgw](https://github.com/rusiaaman/wcgw/blob/main/src/wcgw/client/mcp_server/Readme.md) 🐍 🏠 - Shell execution and computer control
+- [goofypluto999/cv-mirror-mcp](https://github.com/goofypluto999/cv-mirror-mcp) 🟢 🏠 - Lints a CV (PDF/DOCX) against 5 real ATS parsers (Workday, Greenhouse, Lever, Taleo, iCIMS)
 
 ## Community Resources
 


### PR DESCRIPTION
Adds cv-mirror-mcp to the Integration Tools section.

**Repo:** https://github.com/goofypluto999/cv-mirror-mcp

MCP server that lints a CV (PDF or DOCX) against 5 real ATS parsers — Workday, Greenhouse, Lever, Taleo, iCIMS — using heuristics from public vendor docs. Local-only execution; no upload, no telemetry.

- 19 unit tests passing
- Tools exposed: `analyze_cv`, `lint_for_vendor`, `get_express_url`
- Vendor rules cite their public sources

Disclosure: I am the author. Happy to adjust placement, copy, or section.