### PR TITLE
Add ProposalCraft and StatusCraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Track application performance and errors.
 
 - [@modelcontextprotocol/server-sentry](https://github.com/modelcontextprotocol/servers/tree/main/src/sentry) 🐍 ☁️ - Error tracking via Sentry.io
 - [@modelcontextprotocol/server-raygun](https://github.com/MindscapeHQ/mcp-server-raygun) 📱 ☁️ - Crash reporting through Raygun
-- [StatusCraft](https://github.com/jabbawocky/statuscraft) 📱 ☁️ - Live status monitoring for 125 major services (GitHub, AWS, Stripe, OpenAI, etc.) in real time.
+- [StatusCraft](https://github.com/jabbawocky/statuscraft) 📱 ☁️ - Live status monitoring for 141 major services (GitHub, AWS, Stripe, OpenAI, etc.) in real time.
 
 ### Business & Productivity 💼
 Tools for business workflows and professional productivity.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Track application performance and errors.
 
 - [@modelcontextprotocol/server-sentry](https://github.com/modelcontextprotocol/servers/tree/main/src/sentry) 🐍 ☁️ - Error tracking via Sentry.io
 - [@modelcontextprotocol/server-raygun](https://github.com/MindscapeHQ/mcp-server-raygun) 📱 ☁️ - Crash reporting through Raygun
+- [StatusCraft](https://github.com/jabbawocky/statuscraft) 📱 ☁️ - Live status monitoring for 125 major services (GitHub, AWS, Stripe, OpenAI, etc.) in real time.
+
+### Business & Productivity 💼
+Tools for business workflows and professional productivity.
+
+- [ProposalCraft](https://github.com/jabbawocky/proposalcraft) 📱 🏠 - Drafts client proposals in your voice from your past winning work. Built for freelancers and consultants.
 
 ## Development Tools
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Track application performance and errors.
 Tools for business workflows and professional productivity.
 
 - [ProposalCraft](https://github.com/jabbawocky/proposalcraft) 📱 🏠 - Drafts client proposals in your voice from your past winning work. Built for freelancers and consultants.
+- [StandupCraft](https://github.com/jabbawocky/standupcraft) 💻 🏠 - Reads git commits and GitHub activity to generate daily standups, weekly client reports, and sprint retros inside Claude Desktop. No API key required.
 
 ## Development Tools
 


### PR DESCRIPTION
**ProposalCraft** (https://github.com/jabbawocky/proposalcraft) — Drafts client proposals in your voice from your past winning work. 8 tools for freelancers and consultants. No API key required, runs via npx.

**StatusCraft** (https://github.com/jabbawocky/statuscraft) — Live status monitoring for 125 major services (GitHub, AWS, Stripe, OpenAI, Anthropic, etc.). 5 tools, no API key. Great companion for any developer workflow.